### PR TITLE
Set focus by range rather than "focus position."

### DIFF
--- a/common/protobuf/commands.proto
+++ b/common/protobuf/commands.proto
@@ -110,7 +110,8 @@ message Command {
   }
 
   message SetFocusPosition {
-    optional uint32 position = 1;
+    optional uint32 position = 1;   // obsolete; ARIScope will continue to use this in support of pre-2.6 firmware.
+    optional float  focusRange = 2; // in meters; this is the prefered method for firmware 2.6 and later.
   }  
 
   message ForceFocus {


### PR DESCRIPTION
I'm thinking about extending SetFocusPosition to take a range in meters; this is more natural for integration partners and prevents exposure to focus mapping. The 'position' field would continue to be supported by the firmware, but if 'focusRange' is present in the command then range will be used instead. ARIScope will continue to use 'position' in support of older firmware.

Let me know what you think.
