### PR TITLE
Fix a couple more 64-bit warnings.

### DIFF
--- a/tools/arislog/arislog/AvailabilityListener.cpp
+++ b/tools/arislog/arislog/AvailabilityListener.cpp
@@ -32,7 +32,7 @@ AvailabilityListener::AvailabilityListener(
 void AvailabilityListener::Initialize() {
   availabilitySocket_.open(udp::v4());
   availabilitySocket_.set_option(socket_base::reuse_address(true));
-  availabilitySocket_.set_option(socket_base::receive_buffer_size(availabilityBuf_.size()));
+  availabilitySocket_.set_option(socket_base::receive_buffer_size(static_cast<int>(availabilityBuf_.size())));
   availabilitySocket_.bind(udp::endpoint(udp::v4(), Aris2AvailabilityPort));
 
   if (!availabilitySocket_.is_open()) {
@@ -79,7 +79,7 @@ unsigned AvailabilityListener::ParseBeacon(const char * buffer, size_t bufferSiz
 
   aris::Availability message;
 
-  if (message.ParseFromArray(buffer, bufferSize) && message.has_serialnumber()) {
+  if (message.ParseFromArray(buffer, static_cast<int>(bufferSize)) && message.has_serialnumber()) {
     return message.serialnumber();
   }
   else {

--- a/tools/arislog/arislog/arislog.vcxproj
+++ b/tools/arislog/arislog/arislog.vcxproj
@@ -189,6 +189,8 @@
       <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Level3</WarningLevel>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</TreatWarningAsError>
     </ClCompile>
     <ClCompile Include="generated\commands.pb.cc">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -199,6 +201,8 @@
       <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Level3</WarningLevel>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</TreatWarningAsError>
     </ClCompile>
     <ClCompile Include="generated\frame_stream.pb.cc">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -209,6 +213,8 @@
       <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Level3</WarningLevel>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</TreatWarningAsError>
     </ClCompile>
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>


### PR DESCRIPTION
I only fixed warnings in our code.  x64 Release build of arislog still fails because of conversion from 'size_t' to 'int' warnings in code generated by protoc.