### PR TITLE
Put contents of ArisBasics.h in Aris::Common namespace.

### DIFF
--- a/common/code/ArisBasics.h
+++ b/common/code/ArisBasics.h
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 
+namespace Aris {
+  namespace Common {
+
 // These enumerations are essentially duplicates of what was generated
 // by your protoc compiler; however, these serve the purpose of preventing
 // ingress of those generated types into our code base.
@@ -38,3 +41,6 @@ struct AcousticSettings {
   bool            enable150Volts;
   float           receiverGain;
 };
+
+}
+}

--- a/common/code/CommandBuilder/CommandBuilder.cpp
+++ b/common/code/CommandBuilder/CommandBuilder.cpp
@@ -46,7 +46,7 @@ namespace Aris {
       return command;
     }
 
-    aris::Command CommandBuilder::RequestAcousticSettings(const AcousticSettings & settings)
+    aris::Command CommandBuilder::RequestAcousticSettings(const Aris::Common::AcousticSettings & settings)
     {
       Command command;
       command.set_type(Command::SET_ACOUSTICS);

--- a/common/code/CommandBuilder/CommandBuilder.h
+++ b/common/code/CommandBuilder/CommandBuilder.h
@@ -14,7 +14,7 @@ namespace Aris {
       static aris::Command SetFrameStreamReceiver(unsigned int port);
       static aris::Command SetFrameStreamReceiver(const char * ipv4Address, unsigned int port);
       static aris::Command SetFrameStreamSettings(bool interpacketDelayEnable, unsigned interpacketDelayMicroseconds);
-      static aris::Command RequestAcousticSettings(const AcousticSettings & settings);
+      static aris::Command RequestAcousticSettings(const Aris::Common::AcousticSettings & settings);
       static aris::Command Ping();
       static aris::Command SetTelephotoLens(bool present);
       static aris::Command SetFocusRange(float range); // range is in meters

--- a/common/code/FrameRate/FrameRate.cpp
+++ b/common/code/FrameRate/FrameRate.cpp
@@ -43,7 +43,7 @@ namespace Aris {
             return cyclePeriodFactor;
         }
 
-        double CalculateMaxFrameRate(const SystemType systemType,
+        double CalculateMaxFrameRate(const Aris::Common::SystemType systemType,
             const uint32_t samplePeriod,
             const uint32_t samplesPerBeam,
             const uint32_t cyclePeriod,

--- a/common/code/FrameRate/FrameRate.h
+++ b/common/code/FrameRate/FrameRate.h
@@ -7,7 +7,7 @@
 namespace Aris {
     namespace AcousticMath {
 
-        double CalculateMaxFrameRate(const SystemType systemType,
+        double CalculateMaxFrameRate(const Aris::Common::SystemType systemType,
                                      const uint32_t samplePeriod,
                                      const uint32_t samplesPerBeam,
                                      const uint32_t cyclePeriod,

--- a/common/code/FrameRate/UnitTests/unittests.cpp
+++ b/common/code/FrameRate/UnitTests/unittests.cpp
@@ -18,7 +18,7 @@ namespace UnitTests
         TEST_METHOD(SamplesPerBeamLessThan2000FrameRateTest)
         {
             const double expected = 6.04;
-            const double actual = CalculateMaxFrameRate(SystemType::Aris3000,
+            const double actual = CalculateMaxFrameRate(Aris::Common::SystemType::Aris3000,
                 9,      // samplePeriod
                 1999,   // samplesPerBeam
                 19281,  // cyclePeriod
@@ -31,7 +31,7 @@ namespace UnitTests
         TEST_METHOD(SamplesPerBeamGreaterThan2000FrameRateTest)
         {
             const double expected = 5.03;
-            const double actual = CalculateMaxFrameRate(SystemType::Aris3000,
+            const double actual = CalculateMaxFrameRate(Aris::Common::SystemType::Aris3000,
                 9,      // samplePeriod
                 2400,   // samplesPerBeam
                 22890,  // cyclePeriod
@@ -44,7 +44,7 @@ namespace UnitTests
         TEST_METHOD(SamplePeriod7FrameRateTest)
         {
             const double expected = 14.84;
-            const double actual = CalculateMaxFrameRate(SystemType::Aris3000,
+            const double actual = CalculateMaxFrameRate(Aris::Common::SystemType::Aris3000,
                 7,     // samplePeriod
                 1518,  // samplesPerBeam
                 7362,  // cyclePeriod
@@ -57,7 +57,7 @@ namespace UnitTests
         TEST_METHOD(SamplePeriod6FrameRateTest)
         {
             const double expected = 14.01;
-            const double actual = CalculateMaxFrameRate(SystemType::Aris3000,
+            const double actual = CalculateMaxFrameRate(Aris::Common::SystemType::Aris3000,
                 6,     // samplePeriod
                 1518,  // samplesPerBeam
                 7362,  // cyclePeriod
@@ -70,7 +70,7 @@ namespace UnitTests
         TEST_METHOD(SamplePeriod4FrameRateTest)
         {
             const double expected = 13.055;
-            const double actual = CalculateMaxFrameRate(SystemType::Aris3000,
+            const double actual = CalculateMaxFrameRate(Aris::Common::SystemType::Aris3000,
                 4,     // samplePeriod
                 1518,  // samplesPerBeam
                 7362,  // cyclePeriod

--- a/sample-code/vc-using-framestream/vc-using-framestream/AcousticSettings.h
+++ b/sample-code/vc-using-framestream/vc-using-framestream/AcousticSettings.h
@@ -25,12 +25,12 @@ private:
 //  1800: 0
 //  3000: 1
 //  1200: 2
-constexpr AcousticSettings DefaultAcousticSettingsForSystem[3] = {
+constexpr Aris::Common::AcousticSettings DefaultAcousticSettingsForSystem[3] = {
   { // 1800
     0,        // cookie
     15.0,     // frameRate
     3,        // pingMode
-    SonarFrequency::High, // frequency
+    Aris::Common::SonarFrequency::High, // frequency
     1024,     // samplesPerBeam
     2028,     // sampleStartDelay
     10500,    // cyclePeriod
@@ -45,7 +45,7 @@ constexpr AcousticSettings DefaultAcousticSettingsForSystem[3] = {
     0,        // cookie
     15.0,     // frameRate
     9,        // pingMode
-    SonarFrequency::High, // frequency
+    Aris::Common::SonarFrequency::High, // frequency
     946,      // samplesPerBeam
     2028,     // sampleStartDelay
     7118,     // cyclePeriod
@@ -60,7 +60,7 @@ constexpr AcousticSettings DefaultAcousticSettingsForSystem[3] = {
     0,        // cookie
     10.0,     // frameRate
     1,        // pingMode
-    SonarFrequency::High, // frequency
+    Aris::Common::SonarFrequency::High, // frequency
     1082,     // samplesPerBeam
     5408,     // sampleStartDelay
     32818,    // cyclePeriod

--- a/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.cpp
+++ b/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.cpp
@@ -24,7 +24,7 @@ std::pair<ArisBeacons::endpoint, Aris::Common::SystemType> ArisBeacons::FindBySe
       if (message.ParseFromArray(buffer, static_cast<int>(bufferSize)) && message.has_serialnumber()) {
         if (message.serialnumber() == serialNumber) {
           targetEndpoint = ep;
-          systemType = static_cast<SystemType>(message.systemtype());
+          systemType = static_cast<Aris::Common::SystemType>(message.systemtype());
           found = true;
         }
       }

--- a/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.cpp
+++ b/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.cpp
@@ -4,15 +4,15 @@
 #include <iostream>
 
 /* static */
-std::pair<ArisBeacons::endpoint, SystemType> ArisBeacons::FindBySerialNumber(uint32_t serialNumber)
+std::pair<ArisBeacons::endpoint, Aris::Common::SystemType> ArisBeacons::FindBySerialNumber(uint32_t serialNumber)
 {
   boost::asio::io_service io;
 
   volatile bool found = false;
   endpoint targetEndpoint; // assignment on the endpoint type doesn't like volatile
-  SystemType systemType;
+  Aris::Common::SystemType systemType;
 
-  UdpListener udpListener(io, kArisBeaconPort, true, 1024,
+  UdpListener udpListener(io, Aris::Common::kArisBeaconPort, true, 1024,
     [&targetEndpoint, &systemType, &found, serialNumber](auto error, auto ep, auto buffer, auto bufferSize) {
 
       if (error.value()) {

--- a/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.h
+++ b/sample-code/vc-using-framestream/vc-using-framestream/ArisBeacons.h
@@ -15,6 +15,6 @@ public:
 
   // Blocks until it finds it's target. You could probably add a timeout.
   // Returns endpoint and system type.
-  static std::pair<endpoint, SystemType> FindBySerialNumber(uint32_t serialNumber);
+  static std::pair<endpoint, Aris::Common::SystemType> FindBySerialNumber(uint32_t serialNumber);
 };
 

--- a/sample-code/vc-using-framestream/vc-using-framestream/Connection.cpp
+++ b/sample-code/vc-using-framestream/vc-using-framestream/Connection.cpp
@@ -122,7 +122,7 @@ void Connection::HandlePingTimer(const boost::system::error_code & e) {
   }
 }
 
-AcousticSettings Connection::SetCookie(const AcousticSettings & settings)
+Aris::Common::AcousticSettings Connection::SetCookie(const Aris::Common::AcousticSettings & settings)
 {
   auto adjustedSettings = settings;
   adjustedSettings.cookie = cookie_.Next();

--- a/sample-code/vc-using-framestream/vc-using-framestream/Connection.cpp
+++ b/sample-code/vc-using-framestream/vc-using-framestream/Connection.cpp
@@ -22,7 +22,7 @@ constexpr size_t kNetworkBufferSize = 16 * 1024 * 1024;
 std::unique_ptr<Connection> Connection::Create(
   boost::asio::io_service & io,
   std::function<void(Aris::Network::FrameBuilder&)> onFrameCompletion,
-  SystemType systemType,
+  Aris::Common::SystemType systemType,
   aris::Command::SetSalinity::Salinity salinity,
   boost::asio::ip::tcp::endpoint targetSonar,
   const Aris::Network::optional<boost::asio::ip::udp::endpoint> & multicastEndpoint,
@@ -55,7 +55,7 @@ Connection::Connection(
   boost::asio::io_service & io,
   boost::asio::ip::tcp::socket && commandSocket,
   std::function<void(Aris::Network::FrameBuilder&)> onFrameCompletion,
-  SystemType systemType,
+  Aris::Common::SystemType systemType,
   aris::Command::SetSalinity::Salinity salinity,
   boost::asio::ip::address targetSonar,
   const Aris::Network::optional<boost::asio::ip::udp::endpoint> & multicastEndpoint,

--- a/sample-code/vc-using-framestream/vc-using-framestream/Connection.h
+++ b/sample-code/vc-using-framestream/vc-using-framestream/Connection.h
@@ -17,7 +17,7 @@ public:
   static std::unique_ptr<Connection> Create(
     boost::asio::io_service & io, 
     std::function<void(Aris::Network::FrameBuilder&)> onFrameCompletion,
-    SystemType systemType,
+    Aris::Common::SystemType systemType,
     aris::Command::SetSalinity::Salinity salinity,
     boost::asio::ip::tcp::endpoint targetSonar,
     const Aris::Network::optional<boost::asio::ip::udp::endpoint> & multicastEndpoint,
@@ -29,7 +29,7 @@ public:
     boost::asio::io_service & io,
     boost::asio::ip::tcp::socket && commandSocket,
     std::function<void(Aris::Network::FrameBuilder&)> onFrameCompletion,
-    SystemType systemType,
+    Aris::Common::SystemType systemType,
     aris::Command::SetSalinity::Salinity salinity,
     boost::asio::ip::address targetSonar,
     const Aris::Network::optional<boost::asio::ip::udp::endpoint> & multicastEndpoint,
@@ -49,7 +49,7 @@ private:
   const std::vector<uint8_t> ping_template_;
   const std::function<void(const boost::system::error_code&)> sendPing_;
   const std::function<void(Aris::Network::FrameBuilder&)> onFrameCompletion_;
-  const SystemType systemType_;
+  const Aris::Common::SystemType systemType_;
 
   bool hasConnectionError_;
   CookieSequence cookie_;
@@ -60,7 +60,7 @@ private:
   Aris::Network::FrameStreamListener frameStreamListener_;
 
   void HandlePingTimer(const boost::system::error_code& e);
-  AcousticSettings SetCookie(const AcousticSettings & settings);
+  Aris::Common::AcousticSettings SetCookie(const Aris::Common::AcousticSettings & settings);
 
   static std::vector<uint8_t> CreatePingTemplate();
   void SerializeCommand(const aris::Command & cmd, std::vector<uint8_t> & buffer);

--- a/sample-code/vc-using-framestream/vc-using-framestream/main.cpp
+++ b/sample-code/vc-using-framestream/vc-using-framestream/main.cpp
@@ -76,14 +76,14 @@ int main(int argc, char **argv) {
 
   const auto SN = args.serialNumber;
   ArisBeacons::endpoint targetEndpoint;
-  SystemType systemType;
+  Aris::Common::SystemType systemType;
 
   std::tie(targetEndpoint, systemType) = ArisBeacons::FindBySerialNumber(SN);
   std::cout << "  Found target endpoint for SN " << SN << ": " << targetEndpoint.address().to_string() << '\n';
 
   //---------------------------------------------------------------------------
 
-  const auto tcpEndpoint = boost::asio::ip::tcp::endpoint(targetEndpoint.address(), kArisCommandPort);
+  const auto tcpEndpoint = boost::asio::ip::tcp::endpoint(targetEndpoint.address(), Aris::Common::kArisCommandPort);
   std::string errorMessage;
   const auto salinity = aris::Command::SetSalinity::Salinity::Command_SetSalinity_Salinity_SALTWATER;
   const float initialFocusRange = 5.0f;


### PR DESCRIPTION
vc-using-framestream appears to have built successfully after Aris::Common namespace was added.